### PR TITLE
Validate Service name for Deploy functions endpoint

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,0 +1,24 @@
+FROM golang:1.7.5
+
+RUN mkdir -p /go/src/github.com/alexellis/faas-netes/
+
+WORKDIR /go/src/github.com/alexellis/faas-netes
+
+COPY vendor     vendor
+COPY handlers	handlers
+COPY types      types
+COPY server.go  .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o faas-netes .
+
+FROM alpine:3.5
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+
+EXPOSE 8080
+ENV http_proxy      ""
+ENV https_proxy     ""
+
+COPY --from=0 /go/src/github.com/alexellis/faas-netes/faas-netes    .
+
+CMD ["./faas-netes"]

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/replicas.go
+++ b/handlers/replicas.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/server.go
+++ b/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package main
 
 import (

--- a/test/handlers_test.go
+++ b/test/handlers_test.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/alexellis/faas-netes/handlers"
+	"github.com/alexellis/faas/gateway/requests"
+)
+
+func Test_ValidateDeployRequest_ValidCharacters(t *testing.T) {
+	cases := []struct {
+		scenario string
+		value    string
+	}{
+		{"lower", "abz"},
+		{"upper", "ABZ"},
+		{"upper and lower mixed", "AbZ"},
+		{"includes dashes", "test-function"},
+	}
+
+	for _, testCase := range cases {
+		request := requests.CreateFunctionRequest{
+			Service: testCase.value,
+		}
+
+		err := handlers.ValidateDeployRequest(&request)
+		if err != nil {
+			t.Errorf("Scenario: %s with value: %s, got: %s", testCase.scenario, testCase.value, err.Error())
+		}
+
+	}
+}
+
+func Test_ValidateDeployRequest_InvalidCharacters(t *testing.T) {
+	cases := []struct {
+		scenario string
+		value    string
+	}{
+		{"includes hash", "#faas"},
+		{"includes underscore", "test_function"},
+	}
+
+	for _, testCase := range cases {
+		request := requests.CreateFunctionRequest{
+			Service: testCase.value,
+		}
+
+		err := handlers.ValidateDeployRequest(&request)
+		if err == nil {
+			t.Errorf("Expected error for scenario: %s with value: %s, got: %s", testCase.scenario, testCase.value, err.Error())
+		}
+	}
+}

--- a/test/handlers_test.go
+++ b/test/handlers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package test
 
 import (

--- a/types/requests.go
+++ b/types/requests.go
@@ -1,3 +1,6 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package types
 
 type ScaleServiceRequest struct {


### PR DESCRIPTION
K8s won't allow a service name which doesn't conform to a DNS name. a-zA-Z and -

Changes:

* Introduce regex
* Add multi-stage build
* Add MIT license notice to Golang files
