### PR TITLE
Added syntax highlighting

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -39,7 +39,7 @@ Follow the tutorial below, but change your gateway URL from localhost:8080 to ku
 
 i.e.
 
-```
+```yaml
 provider:  
   name: faas
   gateway: http://192.168.4.95:31112

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Given enough load (> 5 requests/second) FaaS will auto-scale your service, you c
 
 Here's an example you can use to generate load:
 
-```
+```bash
 ip=$(minikube ip); while [ true ] ; do curl $ip:31112/function/nodeinfo -d "" ; done
 ```
 


### PR DESCRIPTION
Command outputs are not colored intentionally cause it would need to split command and output to prevent coloring command which could contain different things.